### PR TITLE
Updated context processor to check browser version

### DIFF
--- a/django-webp-converter/setup.cfg
+++ b/django-webp-converter/setup.cfg
@@ -26,3 +26,4 @@ include_package_data = true
 packages = find:
 install_requires = django
                    pillow
+                   httpagentparser

--- a/django-webp-converter/webp_converter/context_processors.py
+++ b/django-webp-converter/webp_converter/context_processors.py
@@ -1,2 +1,47 @@
+import httpagentparser
+from setuptools._vendor.packaging import version
+
+webp_supported_browsers = {
+    'Chrome': '23.0',
+    'Firefox': '65.0',
+    'MSEdge': '18.0',
+    'Opera': '12.10',
+    'Opera Mobile': '12.0'
+}
+
+def _check_user_agent(user_agent):
+    """ Checks if the USER_AGENT supports webp """
+
+    if user_agent:
+        user_agent = httpagentparser.detect(user_agent)
+        browser_name = user_agent.get('browser').get('name', '')
+        browser_version = user_agent['browser'].get('version', '0')  # version not always provided
+    else:  # No USER_AGENT supplied
+        return False
+
+    try:
+        min_version = webp_supported_browsers[browser_name]
+    except KeyError:  # Not a supported browser
+        return False
+    # Ensure brower version supports WEBP
+    if version.parse(browser_version) >= version.parse(min_version):
+        return True
+
+
+def _check_http_accept(http_accept):
+    """ Check if HTTP_ACCEPT header includes webp """
+    return 'webp' in http_accept
+
+
 def webp_support(request):
-    return {"webp_compatible": "image/webp" in request.META.get("HTTP_ACCEPT", {})}
+    http_accept = request.META.get('HTTP_ACCEPT', '')
+    user_agent = request.META.get('HTTP_USER_AGENT')
+
+    if _check_http_accept(http_accept):
+        webp_compatible = True
+    elif _check_user_agent(user_agent):
+        webp_compatible = True
+    else:
+        webp_compatible = False
+
+    return {'webp_compatible': webp_compatible}

--- a/sample_site/tests/test_webp_converter/test_context_processors.py
+++ b/sample_site/tests/test_webp_converter/test_context_processors.py
@@ -2,19 +2,68 @@ from django.test import TestCase
 from django.http import HttpRequest
 from webp_converter.context_processors import webp_support
 
+USER_AGENTS = [
+    # [0] Chrome - supported browser + supported version
+    'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
+
+    # [1] Firefox - supported browser + unsupported version
+    'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:46.0) Gecko/20100101 Firefox/46.0',
+
+    # [2] Safari - unsupported browser
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1'
+]
 
 class TestContextProcessors(TestCase):
-    def test_webp_support_true(self):
-        request = HttpRequest()
-        request.META["HTTP_ACCEPT"] = (
-            "text/html,application/xhtml+xml,application/xml;"
-            "q=0.9,image/webp,*/*;q=0.8"
-        )
-        assert webp_support(request) == {"webp_compatible": True}
 
-    def test_webp_support_false(self):
-        request = HttpRequest()
-        request.META[
-            "HTTP_ACCEPT"
-        ] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-        assert webp_support(request) == {"webp_compatible": False}
+    def setUp(self):
+        self.request = HttpRequest()
+
+    def test_no_user_agent(self):
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertFalse(webp_supported)
+
+    def test_user_agent_supported_browser_supported_version(self):
+        self.request.META['HTTP_USER_AGENT'] = USER_AGENTS[0]
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertTrue(webp_supported)
+
+    def test_user_agent_supported_browser_unsupported_version(self):
+        self.request.META['HTTP_USER_AGENT'] = USER_AGENTS[1]
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertFalse(webp_supported)
+
+    def test_user_agent_unsupported_browser(self):
+        self.request.META['HTTP_USER_AGENT'] = USER_AGENTS[2]
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertFalse(webp_supported)
+
+    def test_http_accept_header_supported(self):
+        self.request.META['HTTP_ACCEPT'] = 'image/webp'
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertTrue(webp_supported)
+
+    def test_http_accept_header_unsupported(self):
+        self.request.META['HTTP_ACCEPT'] = 'image/png'
+        result = webp_support(self.request)
+        webp_supported = result.get('webp_compatible')
+        self.assertFalse(webp_supported)
+
+    # def test_webp_support_true(self):
+    #     request = HttpRequest()
+    #     request.META["HTTP_ACCEPT"] = (
+    #         "text/html,application/xhtml+xml,application/xml;"
+    #         "q=0.9,image/webp,*/*;q=0.8"
+    #     )
+    #     assert webp_support(request) == {"webp_compatible": True}
+    #
+    # def test_webp_support_false(self):
+    #     request = HttpRequest()
+    #     request.META[
+    #         "HTTP_ACCEPT"
+    #     ] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    #     assert webp_support(request) == {"webp_compatible": False}


### PR DESCRIPTION
Some browsers (i.e. Firefox) do not supply 'image/webp' when they do in fact support it. If 'image/webp' is not accepted there is an extra check determine whether the browser is capable of showing webp. 

This is my first ever pull request and I am still fairly new to Django so let me know if there are any issues! Great work on this package otherwise, I am using it on my personal site :)