### PR TITLE
Change cache timeout to infinite

### DIFF
--- a/django-webp-converter/webp_converter/templatetags/webp_converter.py
+++ b/django-webp-converter/webp_converter/templatetags/webp_converter.py
@@ -28,5 +28,5 @@ def static_webp(context, static_path, quality=80):
         if not webp_image.webp_image_exists:
             webp_image.save_webp_image()
         webp_image_url = webp_image.webp_url
-        cache.set(key, webp_image_url)
+        cache.set(key, webp_image_url, timeout=None)
     return webp_image_url


### PR DESCRIPTION
Fetching uncached images takes a lot of time and slows down a request really much.